### PR TITLE
Converting SDK to use httpful

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,11 @@
         {
             "name":"Ahmet Tok",
             "email": "ahmett@acenda.com"
-        }        
+        },
+        {
+        "name":"Brandon Allhands",
+        "email":"brandon@brandonallhands.com"
+        }
 
     ],
 
@@ -25,7 +29,8 @@
 
     "homepage": "http://acenda.com",
     "require":{
-        "php":">=5.3.9"
+        "php":">=5.3.9",
+        "nategood/httpful": "^0.2.19"
     }
 
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,6 @@
 <?php
 namespace Acenda;
+
 use Httpful;
 
 class Client
@@ -11,6 +12,13 @@ class Client
 //    private $ch;
     public $bypass_ssl = false;
 
+    /**
+     * @param $client_id
+     * @param $client_secret
+     * @param $store_url
+     * @param $plugin_name
+     * @throws AcendaException
+     */
     public function __construct($client_id, $client_secret, $store_url, $plugin_name)
     {
         $this->client_id = $client_id;
@@ -20,6 +28,10 @@ class Client
         $this->initConnection();
     }
 
+    /**
+     * @return bool
+     * @throws AcendaException
+     */
     public function initConnection()
     {
         list($http_code, $http_json_response) = $this->performRequest('/oauth/token', 'POST', array('client_id' => $this->client_id,
@@ -38,6 +50,14 @@ class Client
         };
     }
 
+    /**
+     * @param $route
+     * @param $type
+     * @param $data
+     * @return array
+     * @throws AcendaException
+     * @throws Httpful\Exception\ConnectionErrorException
+     */
     public function performRequest($route, $type, $data)
     {
         /*
@@ -69,18 +89,20 @@ class Client
 //        print_r($response);
         if ($response->code != 200) {
             //This is to catch a blank code.
-            $http_code = $response->code?$response->code:400;
+            $http_code = $response->code ? $response->code : 400;
             //There be an error!
             $curl_error['error'] = $response->body->status;
             $curl_error['error_description'] = $response->body->error;
             $http_response = json_encode($curl_error);
         } else {
-            //Then it worked!
+            //Then it worked! We aren't using any of the httpful response magicalness, so return it raw.
+            /*
+             * If someone is interested in said magicalness, it can basically type juggle the response into a stdClass,
+             * So if you have JSON coming back - it comes back json_decoded. If you have XML, it also comes back as stdClass.
+             */
             $http_response = $response->raw_body;
             $http_code = $response->code;
         }
         return array($http_code, $http_response);
     }
 }
-
-?>

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,74 +1,85 @@
 <?php
 namespace Acenda;
+//@todo Acenda SDK has an autoloader - implement using the existing autoloader.
+require __DIR__ . '/../vendor/autoload.php';
+use Httpful;
 
-class Client {
+class Client
+{
     private $client_id;
     private $client_secret;
     private $store_url;
     private $token = ['access_token' => '', 'expires_in' => '', 'token_type' => '', 'scope' => ''];
-    private $ch;
-    public $bypass_ssl=false;
+//    private $ch;
+    public $bypass_ssl = false;
 
-    public function __construct($client_id, $client_secret, $store_url,$plugin_name) {
-        $this->client_id=$client_id;
-        $this->client_secret=$client_secret;
-        $this->store_url=$store_url;
-        $this->plugin_name=$plugin_name;
+    public function __construct($client_id, $client_secret, $store_url, $plugin_name)
+    {
+        $this->client_id = $client_id;
+        $this->client_secret = $client_secret;
+        $this->store_url = $store_url;
+        $this->plugin_name = $plugin_name;
         $this->initConnection();
     }
 
-    public function initConnection() {
-        list($http_code, $http_json_response) = $this->performRequest('/oauth/token', 'POST', array(    'client_id' => $this->client_id,
-                                                                'client_secret' => $this->client_secret, 
-                                                                'grant_type' => 'client_credentials' 
-                                                            )
-                            );
-        $http_response = json_decode($http_json_response,true);
+    public function initConnection()
+    {
+        list($http_code, $http_json_response) = $this->performRequest('/oauth/token', 'POST', array('client_id' => $this->client_id,
+                'client_secret' => $this->client_secret,
+                'grant_type' => 'client_credentials'
+            )
+        );
+        $http_response = json_decode($http_json_response, true);
         switch ($http_code) {
             case 200:
                 $this->token = $http_response;
                 return true;
                 break;
             default:
-                throw new AcendaException($http_code.": ".$http_response['error']." - ".$http_response['error_description']);
-                break;
+                throw new AcendaException($http_code . ": " . $http_response['error'] . " - " . $http_response['error_description']);
         };
     }
-    
-    public function performRequest($route, $type, $data) {
-        $this->ch = curl_init();
+
+    public function performRequest($route, $type, $data)
+    {
+        /*
+         * So, httpful defaults to strict ssl off - so we would really want to invert this logic here.
+         * @todo Talk to Ahmet to see what the use case was for this - and if it needs to remain. I bet it's for local dev testing.
+         */
+        if ($this->bypass_ssl) {
+//            curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
+//            curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, false);
+        }
         $data_json = is_array($data) ? json_encode($data) : $data;
-
-        if ($type == 'GET') {
-            $url = $this->store_url.(!empty($this->token['access_token']) ? "/api".$route."?access_token=".$this->token['access_token'] : $route )."&query=".$data_json;
-        }else if($type == 'POST') {
-            $url = $this->store_url.(!empty($this->token['access_token']) ? "/api".$route."?access_token=".$this->token['access_token'] : $route ); 
-            curl_setopt($this->ch, CURLOPT_POST, true);
-            curl_setopt($this->ch, CURLOPT_POSTFIELDS, $data_json);
-            curl_setopt($this->ch, CURLOPT_HTTPHEADER, array(                                                                          
-                'Content-Type: application/json',
-                'Content-Length: ' . strlen($data_json))
-            );
+        $url = $this->store_url . (!empty($this->token['access_token']) ? "/api" . $route . "?access_token=" . $this->token['access_token'] : $route);
+        switch (strtoupper($type)) {
+            case 'GET':
+                //Append the query.
+                $url .= "&query=" . $data_json;
+                $response = Httpful\Request::get($url)->send();
+                break;
+            case 'PUT':
+                $response = Httpful\Request::put($url, $data_json)->sendsJson()->send();
+                break;
+            case 'POST':
+                $response = Httpful\Request::post($url, $data_json)->sendsJson()->send();
+                break;
+            default:
+                throw new AcendaException('Verb ' . $type . ' Not Understood');
         }
 
-        curl_setopt($this->ch, CURLOPT_URL, $url);
-        curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, 1);
-
-
-        if($this->bypass_ssl){
-            curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-            curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, false);
-        }
-
-        $http_response = curl_exec($this->ch);
-        $http_code = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
-        if (curl_errno($this->ch)) { 
-            $http_code = "400";
-            $curl_error['error'] = curl_errno($this->ch);
-            $curl_error['error_description'] = curl_error($this->ch); 
+//        print_r($response);
+        if ($response->code != 200) {
+            $http_code = 400;
+            //There be an error!
+            $curl_error['error'] = $response->body->error;
+            $curl_error['error_description'] = $response->body->error_description;
             $http_response = json_encode($curl_error);
-        } 
-        curl_close($this->ch);
+        } else {
+            //Then it worked!
+            $http_response = $response->raw_body;
+            $http_code = $response->code;
+        }
         return array($http_code, $http_response);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,11 @@ namespace Acenda;
 
 use Httpful;
 
+/**
+ * Class Client
+ * Primary client for interacting with the Acenda SDK from PHP.
+ * @package Acenda
+ */
 class Client
 {
     private $client_id;
@@ -12,10 +17,10 @@ class Client
     public $bypass_ssl = false;
 
     /**
-     * @param $client_id
-     * @param $client_secret
-     * @param $store_url
-     * @param $plugin_name
+     * @param $client_id Developer ID, usually in form of user@domain.com
+     * @param $client_secret Developer key provided by Acenda.
+     * @param $store_url The URL of the store we are working with.
+     * @param $plugin_name Friendly name for logs etc. I don't think this is implemented.
      * @throws AcendaException
      */
     public function __construct($client_id, $client_secret, $store_url, $plugin_name)

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,7 +1,5 @@
 <?php
 namespace Acenda;
-//@todo Acenda SDK has an autoloader - implement using the existing autoloader.
-require __DIR__ . '/../vendor/autoload.php';
 use Httpful;
 
 class Client

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,11 +82,11 @@ class Client
         }
 
         if ($response->code != 200) {
-            //This is to catch a blank code.
+            //This is to catch a blank code. With httpful - this should never happen.
             $http_code = $response->code ? $response->code : 400;
             //There be an error!
             if ($response->body) {
-                $curl_error['error'] = isset($response->body->error) ? $response->body->error : $response->code;
+                $curl_error['error'] = isset($response->body->error) ? $response->body->error : $http_code;
                 $curl_error['error_description'] = isset($response->body->error_description) ? $response->body->error_description : 'There was an unknown error making the request.';
             }
             $http_response = json_encode($curl_error);

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,10 +68,11 @@ class Client
 
 //        print_r($response);
         if ($response->code != 200) {
-            $http_code = 400;
+            //This is to catch a blank code.
+            $http_code = $response->code?$response->code:400;
             //There be an error!
-            $curl_error['error'] = $response->body->error;
-            $curl_error['error_description'] = $response->body->error_description;
+            $curl_error['error'] = $response->body->status;
+            $curl_error['error_description'] = $response->body->error;
             $http_response = json_encode($curl_error);
         } else {
             //Then it worked!


### PR DESCRIPTION
Hello @torreycommerce/owners. In the downtime today, I converted this SDK over to use httpful instead of raw curl.

This also now supports PUT (Previous seemed to only support GET and POST).

Auth errors don't return error_description - but I don't think the previous version understood that either. I only stumbled across the inconsistency between 'error' and 'error_description' today when I was getting 403s back after the merge.

I am using this in my eBay integration project, and it has worked as a drop in replacement for the current library. I obviously haven't been able to test everything yet - but so far so good. I tried to make it as compatible with the existing SDK as possible.
