### PR TITLE
Query syntax

### DIFF
--- a/Examples/test_connection.php
+++ b/Examples/test_connection.php
@@ -10,7 +10,12 @@ require_once __DIR__.'/../acenda.php';
 
 try {
 	$acenda = new Acenda($config['client_id'], $config['client_secret'], $config['store_url'], @$config['myTestPlugin']);
-	$acenda->performRequest('/order', 'GET', []);
+	$acenda->performRequest('/product', 'GET', [
+        'query' => json_encode(["name":["$regex":"*"]]);
+        'sort' => "date_modified:1",
+        "limit" => 10,
+        "page" => 1
+    ]);
 } catch (Exception $e) {
     echo 'Caught exception: ',  $e->getMessage(), "\n";
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,25 +10,36 @@ use Httpful;
  */
 class Client
 {
+    private $route;
     private $client_id;
     private $client_secret;
     private $store_url;
+    private $acenda_api_url;
+    private $httpful;
     private $token = ['access_token' => '', 'expires_in' => '', 'token_type' => '', 'scope' => ''];
-    public $bypass_ssl = false;
 
     /**
      * @param $client_id Developer ID, usually in form of user@domain.com
      * @param $client_secret Developer key provided by Acenda.
      * @param $store_url The URL of the store we are working with.
      * @param $plugin_name Friendly name for logs etc. I don't think this is implemented.
+     * @param $bypass_ssl Rather the SSL verification should be strict or not.
      * @throws AcendaException
      */
-    public function __construct($client_id, $client_secret, $store_url, $plugin_name)
+    public function __construct($client_id, $client_secret, $store_url, $plugin_name, $bypass_ssl = false)
     {
+        $this->httpful = Httpful\Request::init();
+
         $this->client_id = $client_id;
         $this->client_secret = $client_secret;
-        $this->store_url = $store_url;
+        $this->store_url = $store_url.($store_url[strlen($store_url)-1] == '/' ? 'api' : '/api');
+        $this->acenda_api_url = $store_url;
         $this->plugin_name = $plugin_name;
+
+        if (!$bypass_ssl) {
+            $this->httpful = $this->httpful->withStrictSSL();
+        }
+
         $this->initConnection();
     }
 
@@ -42,20 +53,67 @@ class Client
      */
     public function initConnection()
     {
-        list($http_code, $http_json_response) = $this->performRequest('/oauth/token', 'POST', array('client_id' => $this->client_id,
-                'client_secret' => $this->client_secret,
-                'grant_type' => 'client_credentials'
-            )
-        );
-        $http_response = json_decode($http_json_response, true);
-        switch ($http_code) {
+        $response = $this->httpful->post($this->acenda_api_url.'/oauth/token', json_encode([
+            'client_id' => $this->client_id,
+            'client_secret' => $this->client_secret,
+            'grant_type' => 'client_credentials'
+        ]))->sendsJson()->send();
+
+        switch ($response->code) {
             case 200:
-                $this->token = $http_response;
+                $this->token = json_decode($response->raw_body, true);
                 return true;
                 break;
             default:
                 throw new AcendaException($http_code . ": " . $http_response['error'] . " - " . $http_response['error_description']);
         };
+    }
+
+    private function generate_query($uri, $params=[]){
+        $params = array_merge(['access_token' => $this->token['access_token']], $params);
+
+        $parameters = "";
+        $index = 0;
+        foreach($params as $k => $v){
+            if ($index >= 1){ $parameters .= "&"; }
+            
+            if (is_array($v)){ $parameters .= ($k."=".urlencode(json_encode($v))); }
+            else{ $parameters .= ($k."=".urlencode($v)); } 
+            $index++;
+        }
+
+        $route = $this->store_url;
+        $route .= ($uri[0] == '/') ? $uri : '/'.$uri;
+        $route .= (strpos($uri, '?') == false ? '?' : '&').$parameters;
+        
+        return $route;
+    }
+
+    /**
+    * @param Httpful\Response $response
+    * @return array
+    */
+    protected function requestSuccess(Httpful\Response $response)
+    {
+        $http_response = $response->raw_body;
+        $http_code = $response->code;
+        return array($http_code, $http_response);
+    }
+
+    /**
+    * @param Httpful\Response $response
+    * @return array
+    */
+    protected function requestFailure(Httpful\Response $response)
+    {
+        $http_code = $response->code ? $response->code : 400;
+        $curl_error = [];
+        if ($response->body) {
+            $curl_error['error'] = isset($response->body->error) ? $response->body->error : $http_code;
+            $curl_error['error_description'] = isset($response->body->error_description) ? $response->body->error_description : 'There was an unknown error making the request.';
+        }
+        $http_response = json_encode($curl_error);
+        return array($http_code, $http_response);
     }
 
     /**
@@ -68,27 +126,29 @@ class Client
      */
     public function performRequest($route, $type, $data)
     {
-        $httpful = Httpful\Request::init();
-        if (!$this->bypass_ssl) {
-            $httpful = $httpful->withStrictSSL();
-        }
-        $data_json = is_array($data) ? json_encode($data) : $data;
-        $url = $this->store_url . (!empty($this->token['access_token']) ? "/api" . $route . "?access_token=" . $this->token['access_token'] : $route);
+        if (!is_array($data)){ throw new AcendaException('Wrong parameters provided'); }
+
         switch (strtoupper($type)) {
             case 'GET':
-                //Append the query.
-                $url .= "&query=" . $data_json;
-                $response = $httpful->get($url)->send();
+                $url = $this->generate_query($route, $data);
+                $response = $this->httpful->get($url)->send();
                 break;
             case 'PUT':
-                $response = $httpful->put($url, $data_json)->sendsJson()->send();
+                $url = $this->generate_query($route);
+                $response = $this->httpful->put($url, json_encode($data))->sendsJson()->send();
                 break;
             case 'POST':
-                $response = $httpful->post($url, $data_json)->sendsJson()->send();
+                $url = $this->generate_query($route);
+                $response = $this->httpful->post($url, json_encode($data))->sendsJson()->send();
+                break;
+            case 'DELETE':
+                $url = $this->generate_query($route, $data);
+                $response = $this->httpful->delete($url)->sendsJson()->send();
                 break;
             default:
-                throw new AcendaException('Verb ' . $type . ' Not Understood');
+                throw new AcendaException('Verb not recognized yet');
         }
+
         //Default in this switch is failure. All failures should fall through to default.
         switch ($response->code) {
             case 200:
@@ -97,32 +157,5 @@ class Client
             default:
                 return $this->requestFailure($response);
         }
-    }
-
-    /**
-     * @param Httpful\Response $response
-     * @return array
-     */
-    protected function requestSuccess(Httpful\Response $response)
-    {
-        $http_response = $response->raw_body;
-        $http_code = $response->code;
-        return array($http_code, $http_response);
-    }
-
-    /**
-     * @param Httpful\Response $response
-     * @return array
-     */
-    protected function requestFailure(Httpful\Response $response)
-    {
-        $http_code = $response->code ? $response->code : 400;
-        $curl_error = [];
-        if ($response->body) {
-            $curl_error['error'] = isset($response->body->error) ? $response->body->error : $http_code;
-            $curl_error['error_description'] = isset($response->body->error_description) ? $response->body->error_description : 'There was an unknown error making the request.';
-        }
-        $http_response = json_encode($curl_error);
-        return array($http_code, $http_response);
     }
 }


### PR DESCRIPTION
This merge includes mostly the management of the query in a more complex way.
You will now be able to manage your queries like that:

``` php
// Initalization of the API client with your credentials
$cli = new Acenda(_CLIENT_ID_, _CLIENT_SECRET_, _STORE_URL_, _NAME_);

// Basic case of querying with syntax system and sorting
$response = $cli->performRequest('/order', 'GET', [
    'query' => json_encode(
        ['id' => ['$in' => [42, 21]]]
    ),
    'sort' => 'date_modified:1',
    'limit' => 300,
    'page' => 1
]);
```

In addition of that, the SSL verification parameter is also added to the constructor of the client as optional parameter.

``` php
public function __construct($client_id, $client_secret, $store_url, $plugin_name, $bypass_ssl = false){
// Class
}
```

Then finally the initConnection no longer uses performRequest.
