### PR TITLE
Flipping operator to check for token expiration time vs current time.…

### DIFF
--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -19,7 +19,9 @@ class Authentication{
      * @return bool
      */
     private static function generation(){
-        if (empty(static::$instance) || static::$instance->expires >= date("U")){
+        //Give us 10 seconds of padding, which should be plenty. This method is called every request, so the token
+        //should be used within microseconds of this method.
+        if (empty(static::$instance) || static::$instance->expires <= time() + 10){
             static::$instance = new Authentication();
         }
 


### PR DESCRIPTION
… Adding 10 seconds of padding. If token expires within next 10 seconds, get a new token.

This assumes we are getting a timestamp here (It always has). Properly should be comparing two known like objects, like DateTime() - but this will work to resolve the "new token every request" issue.
