### PR TITLE
Client: retry low level connection exceptions

### DIFF
--- a/src/AcendaException.php
+++ b/src/AcendaException.php
@@ -13,8 +13,8 @@ class AcendaException extends Exception{
     public $body;
 
     /**
-     * @param $code HTTP code
-     * @param $body Content of the body.
+     * @param string|int $code HTTP Code
+     * @param string $body content of the body.
      */
     public function __construct($code, $body){
         $this->code = $code;


### PR DESCRIPTION
Retry low level request failures automatically, up to 5 times. Concealing httpful request exception from SDK users.

Cleaning up performRequest/Header authentication. Removing token from query string.